### PR TITLE
Enable python logging and add a bit more documentation.

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -3,7 +3,7 @@
 ## Importing models
 
 ```
-import_models.py
+python import_models.py --help
 
 usage: This script imports CNTK models to ELL from a given search path
 
@@ -35,16 +35,15 @@ optional arguments:
 
 ```
 python test_models.py --help                                                                   
-usage: This script tests all ELL models found under a path, sequentially or in parallel.         
-                                                                                                 
-       [-h] [--path PATH] [--parallel PARALLEL] [--labels LABELS]                                
-       [--target {pi0,pi3}] [--cluster CLUSTER] [--val_set VAL_SET]                              
-       [--val_map VAL_MAP]                                                                       
-                                                                                                 
-optional arguments:                                                                              
-  -h, --help           show this help message and exit                                           
-  --path PATH          the model search path (or current directory if not                        
-                       specified)                                                                
+
+
+usage: This script tests all ELL models found under a path, sequentially or in parallel.
+
+       [-h] [--path PATH] [--parallel True] [--val_map file] [--val_set path]
+
+optional arguments:
+  -h, --help           show this help message and exit
+  --path PATH          the model search path (or current directory if not specified)
   --parallel PARALLEL  test models in parallel (defaults to True)                                
   --labels LABELS      path to the labels file for evaluating the model                          
   --target {pi0,pi3}   the target platform                                                       
@@ -52,41 +51,71 @@ optional arguments:
                        to the target devices                                                     
   --val_set VAL_SET    path to the validation set images                                         
   --val_map VAL_MAP    path to the validation set truth                                          
-                                                                                                 
+
+
 ```
-- Run from any folder hierarchy containing *.ell.zip.  The hierarchy can be anything because we do a glob on that file extension.
-- This calls drivetest.py under the covers, and another test called run_validation.py that executes across the validation set.
-- By default this uses dask.threaded to test models in parallel. If you run into any trouble with parallel execution of tests, you can always force the tests to run sequentially by setting --parallel False
+- The tool searches the --path directory tree for *.ell.zip files and will test all of them.
+- This calls [drivetest.py](https://github.com/Microsoft/ELL/blob/master/tools/utilities/pitest/drivetest.py) under the covers, 
+and [run_validation.py](https://github.com/Microsoft/ELL/blob/master/tools/utilities/pythonlibs/gallery/run_validation.py) which 
+executes the compiled model across a given validation set.
+- If --parallel is True it uses dask.threaded to test models in parallel up to a maximum of 20 threads. If you run into any trouble with 
+parallel execution of tests, you can always force the tests to run sequentially by setting --parallel False.
 
-- Setup
-  - Map the Y drive (or any drive to the validation set), like this:
-    ```
-    Directory of Y:\
+### VAL_MAP file 
+This is a simple text file contains each image file name and the expected prediction that matches that image, like this:
+```
+  buffalo.png 346
+  crocadile.png 49
+  dungbeetle.png 305
+  elephant.png 386
+  hippo.png 344
+  hyena.png 276
+  impala.png 352
+  leopard.png 293
+  lion.png 291
+  stork.png 43
+  warthog.png 343
+  wolf.jpeg 81
+  zebra.png 340
+```
+### VAL_SET path
 
-        XX/XX/2017  05:13 PM    <DIR>          .
-        XX/XX/2017  12:20 PM    <DIR>          ..
-        XX/XX/2017  03:43 PM         2,044,500 val_map.txt
-        XX/XX/2017  05:46 PM    <DIR>          images
-    ```
+This path contains the images mentioned in the VAL_MAP file.  Using the above example, the folder should contain a file 
+named "buffalo.png" as well as all the other images in that list.
 
-- Examples
-  - To test multiple models:
-    ```
+### Examples
+    Assuming you have the following environment variables defined:
+
     set ell_root=<your_ell_root>
-    cd <ELL-models>\models\ILSVRC2012 (or any folder structure with models)
-    (py36) python <ELL-models>\scripts\test_models.py --cluster CLUSTER_IP --val_set Y:\images --val_map Y:\images\val_map.txt
+    set cluster=<your test machine cluster web service>
+    set images=<path to your test images>
+
+  - To test multiple models in parallel:
+    ```
+    cd <ELL-models>\models\ILSVRC2012 (or any folder structure containing multiple models)
+    (py36) python <ELL-models>\scripts\test_models.py --cluster %cluster% --val_map %images%\val_map.txt --val_set %images%
     ```
 
-  - To test any model:
+  - To test a single model:
     ```
-    set ell_root=<your_ell_root>
-    cd <ELL-models>\models\ILSVRC2012\dscs2_I128x128x3CCCCCCC1AS
-    (py36) python <ELL-models>\scripts\test_models.py --cluster CLUSTER_IP --val_set Y:\images --val_map Y:\images\val_map.txt
+    (py36) python <ELL-models>\scripts\test_model.py --cluster %cluster% -val_map %images%\val_map.txt --val_set %images%
     ```
 
   - To test multiple models, sequentially:
     ```
-    set ell_root=<your_ell_root>
-    cd <ELL-models>\models\ILSVRC2012 (or any folder structure with models)
-    (py36) python <ELL-models>\scripts\test_models.py --parallel False  --cluster CLUSTER_IP --val_set Y:\images --val_map Y:\images\val_map.txt
+    (py36) python <ELL-models>\scripts\test_models.py --cluster %cluster% --val_map %images%\val_map.txt --val_set %images% --parallel False
     ```
+  
+  - To move the temp files created by this process out of the ELL-models location, use the --path variable:
+  
+    ```
+    cd d:\temp\foo
+    (py36) python <ELL-models>\scripts\test_models.py --cluster %cluster% --val_map %images%\val_map.txt --val_set %images% --path <ELL-models>\models\ILSVRC2012
+    ```
+
+### Cluster Web Service
+
+Your cluster web service manages the locking and unlocking of test machines.  Your service must implement the
+[picluster.py](https://github.com/Microsoft/ELL/blob/master/tools/utilities/pythonlibs/picluster.py) API which 
+is a simple RESTful web service that makes it possible to centrally get/lock/unlock machines so that multiple
+people in your group can share the same pool of test machines.  

--- a/scripts/test_model.py
+++ b/scripts/test_model.py
@@ -44,9 +44,9 @@ class TestModel:
         self.arg_parser.add_argument("--labels", help="path to the labels file for evaluating the model", default="categories.txt")
         self.arg_parser.add_argument("--target", help="the target platform", choices=["pi0", "pi3"], default="pi3")
         self.arg_parser.add_argument("--cluster", help="http address of the cluster server that controls access to the target devices",
-                                     default=None)
-        self.arg_parser.add_argument("--val_set", help="path to the validation set images")
-        self.arg_parser.add_argument("--val_map", help="path to the validation set truth")
+                                     default=None, required=True)
+        self.arg_parser.add_argument("--val_set", help="path to the validation set images", required=True)
+        self.arg_parser.add_argument("--val_map", help="path to the validation set truth", required=True)
         self.arg_parser.add_argument("--test_dir", help="the folder on the host to collect model files", default="test")
 
         args = self.arg_parser.parse_args(argv)

--- a/scripts/test_models.py
+++ b/scripts/test_models.py
@@ -51,9 +51,10 @@ class TestModels:
         self.arg_parser.add_argument("--parallel", type=bool, help="test models in parallel (defaults to True)", default=True)
         self.arg_parser.add_argument("--labels", help="path to the labels file for evaluating the model", default="categories.txt")
         self.arg_parser.add_argument("--target", help="the target platform", choices=["pi0", "pi3"], default="pi3")
-        self.arg_parser.add_argument("--cluster", help="http address of the cluster server that controls access to the target devices")
-        self.arg_parser.add_argument("--val_set", help="path to the validation set images")
-        self.arg_parser.add_argument("--val_map", help="path to the validation set truth")
+        self.arg_parser.add_argument("--cluster", help="http address of the cluster server that controls access to the target devices"
+            , required=True)
+        self.arg_parser.add_argument("--val_set", help="path to the validation set images", required=True)
+        self.arg_parser.add_argument("--val_map", help="path to the validation set truth", required=True)
 
         args = self.arg_parser.parse_args(argv)
         self.path = args.path

--- a/scripts/test_models.py
+++ b/scripts/test_models.py
@@ -13,6 +13,7 @@ import os
 import sys
 import argparse
 import glob
+import logging
 import test_model
 
 from os.path import basename, dirname, isdir, join, splitext
@@ -35,6 +36,7 @@ class TestModels:
         self.cluser = None
         self.target = "pi3"
         self.labels = None
+        self.logger = logging.getLogger(__name__)
 
         if not 'ell_root' in os.environ:
             raise EnvironmentError("ell_root environment variable not set")
@@ -62,6 +64,11 @@ class TestModels:
         self.val_set = args.val_set
         self.val_map = args.val_map
 
+        if self.parallel:            
+            logging.basicConfig(level=logging.INFO, format="%(asctime)s [%(thread)d]: %(message)s")
+        else:
+            logging.basicConfig(level=logging.INFO, format="%(message)s")
+
         if not self.path:
             self.path = os.getcwd()
         elif not isdir(self.path):
@@ -84,20 +91,20 @@ class TestModels:
                 tm.run()
         except:
             errorType, value, traceback = sys.exc_info()
-            print("### Exception: " + str(errorType) + ": " + str(value))
+            self.logger.error("### Exception: " + str(errorType) + ": " + str(value))
             return False
         return True
 
     def _run_tests(self):
         "Tests each model"
         if self.parallel:
-            print("Running in parallel")
+            self.logger.info("Running in parallel")
             import dask.threaded
             from dask import compute, delayed
             values = [delayed(self._run_test)(model_path) for model_path in self.model_dirs]
             compute(*values, get=dask.threaded.get)
         else:
-            print("Running sequentially")
+            self.logger.info("Running sequentially")
             for model_path in self.model_dirs:
                 self._run_test(model_path)
 


### PR DESCRIPTION
When composing our scripts into larger scenarios like the test_models.py, which uses cntk_importer, wrap, and various other validation scripts, and it does that with parallel threads, it works better if all output is sent through the python "logger".  For example, test_models can enable a logging format like this and see output from the different threads:
```
logging.basicConfig(level=logging.INFO, format="%(asctime)s [%(thread)d]: %(message)s")
```
which results in this:
```
(ell) d:\temp\models>python d:\git\ell\ELL-models\scripts\test_models.py --cluster http://pidatacenter.cloudapp.net/api/values --val_map d:\temp\images\val_map.txt  --val_set d:\temp\images
2018-01-11 18:49:51,041 [15392]: Running in parallel
2018-01-11 18:49:51,512 [34484]: note: machine at 157.54.156.146 is not sending heartbeats
2018-01-11 18:49:52,116 [23536]: Locked machine at 10.196.45.163
2018-01-11 18:49:52,458 [29948]: Locked machine at 157.54.156.63
2018-01-11 18:49:52,842 [34484]: Locked machine at 10.196.45.187
2018-01-11 18:49:53,385 [34484]: extracted: d:\temp\models\d_I160x160x3CMCMBMBMBMBMC1AS.ell
2018-01-11 18:49:53,387 [34484]: downloading default categories.txt...
2018-01-11 18:49:53,387 [34484]: Downloading: https://github.com/Microsoft/ELL-models/raw/master/models/ILSVRC2012//categories.txt
2018-01-11 18:49:53,407 [23536]: extracted: d:\temp\models\d_I160x160x3CMCMBMBMBMBMB1AS.ell
2018-01-11 18:49:53,409 [23536]: downloading default categories.txt...
2018-01-11 18:49:53,409 [23536]: Downloading: https://github.com/Microsoft/ELL-models/raw/master/models/ILSVRC2012//categories.txt
2018-01-11 18:49:54,597 [34484]: using ELL model: d_I160x160x3CMCMBMBMBMBMC1AS
2018-01-11 18:49:54,598 [23536]: using ELL model: d_I160x160x3CMCMBMBMBMBMB1AS

```
Other useful logging prefixes can be useful during debugging of the script, for example, prepending each message with the module name.  Or for production use you can reduce the noise level and set level=logging.WARNING which will hide all INFO messages.